### PR TITLE
Fix duplicated auth utils in edit profile

### DIFF
--- a/pages/edit-profile.js
+++ b/pages/edit-profile.js
@@ -10,66 +10,6 @@ import {
   logout
 } from '../js/modules/auth.js';
 
-function getAccessToken() {
-  return localStorage.getItem('userToken');
-}
-
-function setAccessToken(token) {
-  localStorage.setItem('userToken', token);
-}
-
-function getRefreshToken() {
-  return localStorage.getItem('refreshToken');
-}
-
-function setRefreshToken(token) {
-  localStorage.setItem('refreshToken', token);
-}
-
-function clearTokens() {
-  localStorage.removeItem('userToken');
-  localStorage.removeItem('refreshToken');
-}
-
-async function fetchWithAuth(url, options = {}) {
-  let accessToken = getAccessToken();
-  const refreshToken = getRefreshToken();
-
-  if (!accessToken || !refreshToken) {
-    throw new Error('User not authenticated');
-  }
-
-  options.headers = options.headers || {};
-  options.headers['Authorization'] = `Bearer ${accessToken}`;
-
-  let response = await fetch(url, options);
-
-  if (response.status === 401 || response.status === 403) {
-    // Try refreshing access token
-    const refreshResponse = await fetch(`${API_BASE}/token`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: refreshToken }),
-    });
-
-    if (!refreshResponse.ok) {
-      // Refresh token invalid or expired → force logout
-      clearTokens();
-      window.location.href = '/login.html';
-      throw new Error('Session expired. Please log in again.');
-    }
-
-    const data = await refreshResponse.json();
-    const newAccessToken = data.accessToken;
-    setAccessToken(newAccessToken);
-
-    // Retry original request with new access token
-    options.headers['Authorization'] = `Bearer ${newAccessToken}`;
-    response = await fetch(url, options);
-  }
-
-  return response;
-}
 
 const token = getAccessToken();
 const form = document.getElementById('profileForm');
@@ -88,7 +28,7 @@ async function fetchProfile() {
   const userId = getUserIdFromToken();
   if (!userId) {
     alert('Invalid token, please log in again.');
-    removeTokens();
+    clearTokens();
     window.location.href = '/login.html'; // Use absolute path here too
     return;
   }


### PR DESCRIPTION
## Summary
- remove duplicate authentication helpers from `edit-profile.js`
- use `clearTokens()` when auth token is invalid

## Testing
- `node --check pages/edit-profile.js`
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6853d2692b18832081865dd92e87a946