### PR TITLE
Add tests for auth utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Bradspelsmeny
+
+## Running tests
+
+Install Node.js (v18+). Then run:
+
+```bash
+npm test
+```
+
+This uses Node's built-in test runner (`node --test`).

--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -19,13 +19,13 @@ export function getAccessToken() {
     }
   }
   
-  function parseJwt(token) {
-    try {
-      return JSON.parse(atob(token.split('.')[1]));
-    } catch {
-      return null;
-    }
+export function parseJwt(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch {
+    return null;
   }
+}
   
   export function getUserRole() {
     const token = getAccessToken();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bradspelsmeny",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, it, afterEach } from 'node:test';
+import { parseJwt, getAccessToken, getUserRole } from '../js/modules/auth.js';
+
+// Simple in-memory localStorage mock
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: key => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: key => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    }
+  };
+})();
+
+global.localStorage = localStorageMock;
+
+describe('auth utilities', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('parseJwt returns payload for valid token', () => {
+    const payload = { role: 'admin' };
+    const token = ['eyJoZWFkZXIiOiAiIn0=', btoa(JSON.stringify(payload)), 'sig'].join('.');
+    const decoded = parseJwt(token);
+    assert.deepEqual(decoded, payload);
+  });
+
+  it('parseJwt returns null for invalid token', () => {
+    const decoded = parseJwt('invalid.token');
+    assert.equal(decoded, null);
+  });
+
+  it('getAccessToken reads token from localStorage', () => {
+    localStorage.setItem('userToken', 'abc123');
+    assert.equal(getAccessToken(), 'abc123');
+  });
+
+  it('getUserRole returns role from valid token', () => {
+    const payload = { role: 'user' };
+    const token = ['e30', btoa(JSON.stringify(payload)), 'sig'].join('.');
+    localStorage.setItem('userToken', token);
+    assert.equal(getUserRole(), 'user');
+  });
+
+  it('getUserRole returns null with invalid token', () => {
+    localStorage.setItem('userToken', 'invalid');
+    assert.equal(getUserRole(), null);
+  });
+
+  it('getUserRole returns null with no token', () => {
+    assert.equal(getUserRole(), null);
+  });
+});


### PR DESCRIPTION
## Summary
- export `parseJwt`
- add Node test setup and authentication utility tests
- document test instructions in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853d542ddb4832084a9905ea267101e