### PR TITLE
Fix transparent typo

### DIFF
--- a/css/shared-ui.css
+++ b/css/shared-ui.css
@@ -103,13 +103,13 @@
   color:white;
   padding:10px;
   border-radius:50%;
-  background:transperant;
+  background:transparent;
   cursor:pointer;
   z-index:1000;
   transition:background-color 0.3s ease,transform 0.2s ease;
 }
 #notificationIcon:hover {
-  background:transperant;
+  background:transparent;
   transform:scale(1.05);
 }
 .notification-item button {


### PR DESCRIPTION
## Summary
- fix 'transperant' typo in notification icon styles

## Testing
- `grep -n "transperant" -r css/shared-ui.css`


------
https://chatgpt.com/codex/tasks/task_e_6853d52a1fe48320a40e2677edaafe75